### PR TITLE
Inject actions in a smaller container by their tags thanks to Symfony 4.3

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,4 +1,4 @@
-# This file is the entry point to configure the application services.
+# This file is the entry point to configure the application's services.
 
 # Files in the packages/ subdirectory configure your dependencies.
 imports:
@@ -22,10 +22,9 @@ services:
         resource: '../src/*'
         exclude: '../src/{Kernel.php}'
 
-    # The actions are registered separately because they need to be public and in order to add them the "app.action" tag
+    # The actions are registered separately in order to add them the "app.action" tag
     App\Action\:
         resource: '../src/Action'
-        public: true
         tags: ['app.action']
 
     # The request handler goal is to execute the middleware stack given as arguments
@@ -37,6 +36,11 @@ services:
             - '@App\Middleware\ExceptionHandler'
             - '@App\Middleware\Router'
             - '@App\Middleware\ActionHandler'
+
+    # Inject a smaller container which contains only the actions
+    App\Middleware\ActionHandler:
+        arguments:
+            $actionLocator: !tagged_locator { tag: 'app.action' }
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Middleware/ActionHandler.php
+++ b/src/Middleware/ActionHandler.php
@@ -19,11 +19,11 @@ use Psr\Http\Server\RequestHandlerInterface;
 final class ActionHandler implements MiddlewareInterface
 {
     /** @var ContainerInterface */
-    private $container;
+    private $actionLocator;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $actionLocator)
     {
-        $this->container = $container;
+        $this->actionLocator = $actionLocator;
     }
 
     /**
@@ -35,14 +35,14 @@ final class ActionHandler implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $action = $request->getAttribute('action');
-        if (!$this->container->has($action)) {
+        if (!$this->actionLocator->has($action)) {
             throw new ActionNotFoundException(
                 $action,
                 $request->getAttribute('route')
             );
         }
 
-        $action = $this->container->get($action);
+        $action = $this->actionLocator->get($action);
         if (!$action instanceof RequestHandlerInterface) {
             throw new InvalidActionTypeException($action);
         }

--- a/src/Middleware/ActionHandler.php
+++ b/src/Middleware/ActionHandler.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * The action handler try to execute an action based on the request and return the response from it.
@@ -34,15 +35,14 @@ final class ActionHandler implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $action = $request->getAttribute('action');
-        if (!$this->actionLocator->has($action)) {
-            throw new ActionNotFoundException(
-                $action,
-                $request->getAttribute('route')
-            );
+        $actionClassName = $request->getAttribute('action');
+
+        try {
+            $action = $this->actionLocator->get($actionClassName);
+        } catch (ServiceNotFoundException $serviceNotFoundException) {
+            throw new ActionNotFoundException($actionClassName, $request->getAttribute('route'));
         }
 
-        $action = $this->actionLocator->get($action);
         if (!$action instanceof RequestHandlerInterface) {
             throw new InvalidActionTypeException($action);
         }


### PR DESCRIPTION
I discovered this feature today thanks to this [article](https://olvlvl.com/2019-09-symfony-tagged-service-locator).

That's a nice way to inject a smaller container in the ActionHandler middleware. This new container (or ServiceLocator) will only contains services tagged with 'app.action'.

As a bonus, the actions private in the main container can now be private.